### PR TITLE
chore: add phpstan baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,5 +7,6 @@
 /gulpfile.js export-ignore
 /phpcs.xml export-ignore
 /phpstan.neon.dist export-ignore
+/phpstan-baseline.neon export-ignore
 /phpunit.xml export-ignore
 /tests export-ignore

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to an undefined property Faker\\\\UniqueGenerator\\:\\:\\$email\\.$#"
+			count: 1
+			path: database/factories/UserFactory.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,5 @@
 includes:
+    - phpstan-baseline.neon
     - ./vendor/nunomaduro/larastan/extension.neon
     - ./vendor/phpstan/phpstan-mockery/extension.neon
 


### PR DESCRIPTION
Baseline is required to ensure CI keeps passing. This error is a problem in `fakerphp/faker` which is expected to be resolved in `v1.16.0`