### PR TITLE
fix: garbage collect only empty channels

### DIFF
--- a/src/PollcastBroadcaster.php
+++ b/src/PollcastBroadcaster.php
@@ -122,9 +122,13 @@ class PollcastBroadcaster extends Broadcaster
                 ->with('channel')
                 ->where('updated_at', '<', Carbon::now()->subMilliseconds($pollingInterval * 6)->toDateTimeString())
                 ->each(function (Member $member) {
-                    /** @var Channel $channel */
+                    /** @var Channel|null $channel */
                     $channel = $member->channel;
-                    $this->socket->removeMemberFromChannel($member, $channel);
+                    if ($channel) {
+                        $this->socket->removeMemberFromChannel($member, $channel);
+                    } else {
+                        $member->delete();
+                    }
                 });
 
             Channel::query()

--- a/src/PollcastBroadcaster.php
+++ b/src/PollcastBroadcaster.php
@@ -117,24 +117,22 @@ class PollcastBroadcaster extends Broadcaster
             ->where('created_at', '<', Carbon::now()->subMilliseconds($pollingInterval * 6)->toDateTimeString())
             ->delete();
 
-        DB::transaction(function () use ($pollingInterval) {
-            Member::query()
-                ->with('channel')
-                ->where('updated_at', '<', Carbon::now()->subMilliseconds($pollingInterval * 6)->toDateTimeString())
-                ->each(function (Member $member) {
-                    /** @var Channel|null $channel */
-                    $channel = $member->channel;
-                    if ($channel) {
-                        $this->socket->removeMemberFromChannel($member, $channel);
-                    } else {
-                        $member->delete();
-                    }
-                });
+        Member::query()
+            ->with('channel')
+            ->where('updated_at', '<', Carbon::now()->subMilliseconds($pollingInterval * 6)->toDateTimeString())
+            ->each(function (Member $member) {
+                /** @var Channel|null $channel */
+                $channel = $member->channel;
+                if ($channel) {
+                    $this->socket->removeMemberFromChannel($member, $channel);
+                } else {
+                    $member->delete();
+                }
+            });
 
-            Channel::query()
-                ->where('updated_at', '<', Carbon::now()->subDay()->toDateTimeString())
-                ->delete();
-        });
+        Channel::query()
+            ->where('updated_at', '<', Carbon::now()->subDay()->toDateTimeString())
+            ->delete();
     }
 
     /**

--- a/tests/Unit/PollcastBroadcasterTest.php
+++ b/tests/Unit/PollcastBroadcasterTest.php
@@ -133,10 +133,17 @@ class PollcastBroadcasterTest extends TestCase
         $member1 = factory(Member::class)->create([
             'channel_id' => $channel2->id,
             'updated_at' => Carbon::now()->subSeconds(45)->toDateTimeString(),
+            'data'       => ['member1']
         ]);
         $member2 = factory(Member::class)->create([
             'channel_id' => $channel2->id,
             'updated_at' => Carbon::now()->subSeconds(5)->toDateTimeString(),
+            'data'       => ['member2']
+        ]);
+        $member3 = factory(Member::class)->create([
+            'channel_id' => $channel1->id,
+            'updated_at' => Carbon::now()->subSeconds(45)->toDateTimeString(),
+            'data'       => ['member3']
         ]);
 
         $message1 = factory(Message::class)->create([
@@ -154,8 +161,12 @@ class PollcastBroadcasterTest extends TestCase
         $this->assertDatabaseHas('pollcast_channel', ['id' => $channel2->id]);
         $this->assertDatabaseMissing('pollcast_channel_members', ['id' => $member1->id]);
         $this->assertDatabaseHas('pollcast_channel_members', ['id' => $member2->id]);
+        $this->assertDatabaseMissing('pollcast_channel_members', ['id' => $member3->id]);
         $this->assertDatabaseHas('pollcast_message_queue', ['id' => $message1->id]);
         $this->assertDatabaseMissing('pollcast_message_queue', ['id' => $message2->id]);
+
+        $this->assertDatabaseHas('pollcast_message_queue', ['event' => 'pollcast:member_removed', 'payload' => json_encode($member1->data)]);
+        $this->assertDatabaseMissing('pollcast_message_queue', ['event' => 'pollcast:member_removed', 'payload' => json_encode($member3->data)]);
     }
 
     public function testBroadcastGarbageCollectionWithDifferentInterval(): void


### PR DESCRIPTION
Channels were being removed first, so due to the foreign key (`ON DELETE CASCADE`) there was a chance that it would remove members from a channel before it 'officially' removed them.

The method broadcasts a message about their removal, which is not done if they are removed by the foreign key, this change should ensure that it always broadcasts members being removed before the channel is deleted.