### PR TITLE
fix: #8 - add microseconds level of precision to message queue table

### DIFF
--- a/database/migrations/2021_06_10_155560_create_pollcast_message_queue_table.php
+++ b/database/migrations/2021_06_10_155560_create_pollcast_message_queue_table.php
@@ -29,7 +29,7 @@ class CreatePollcastMessageQueueTable extends Migration
 
             $table->text('event');
             $table->text('payload');
-            $table->timestamps();
+            $table->timestamps(6);
 
             $table->index('created_at');
         });

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -65,4 +65,9 @@ class Message extends Model
 
         return $this;
     }
+
+    public function getDateFormat(): string
+    {
+        return 'Y-m-d H:i:s.u';
+    }
 }

--- a/tests/Functional/Controller/SubscriptionTest.php
+++ b/tests/Functional/Controller/SubscriptionTest.php
@@ -89,7 +89,7 @@ class SubscriptionTest extends TestCase
         $event = 'test-event';
         $message1 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:56.123456']);
         $message2 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:56.023456']);
-        $message3 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:58.123465']);
+        $message3 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:56.123465']);
 
         $this->postAjax(route('supportpal.pollcast.receive'), [
             'channels' => [$channel->name => [$event]],

--- a/tests/Functional/Controller/SubscriptionTest.php
+++ b/tests/Functional/Controller/SubscriptionTest.php
@@ -87,9 +87,9 @@ class SubscriptionTest extends TestCase
         [$channel,] = $this->setupChannelAndMember();
 
         $event = 'test-event';
-        $message1 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:57']);
-        $message2 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:56']);
-        $message3 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:58']);
+        $message1 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:56.123456']);
+        $message2 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:56.023456']);
+        $message3 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:58.123465']);
 
         $this->postAjax(route('supportpal.pollcast.receive'), [
             'channels' => [$channel->name => [$event]],


### PR DESCRIPTION
https://github.com/supportpal/pollcast/pull/9 didn't completely resolve #8, if there are entries at the same second then it could still be in the incorrect order. This adds precision to the timestamps so it can order them correctly.