### PR TITLE
fix: #8 - use fractional seconds on php 7.2

### DIFF
--- a/src/Http/Controller/PublishController.php
+++ b/src/Http/Controller/PublishController.php
@@ -18,11 +18,9 @@ class PublishController
             ->where('name', $request->channel_name)
             ->firstOrFail();
 
-        (new Message([
-            'channel_id' => $channel->id,
-            'event'      => $request->event,
-            'payload'    => $request->data,
-        ]))->save();
+        Message::insert([
+            Message::make($channel->id, $request->event, $request->data)
+        ]);
 
         return new JsonResponse([true]);
     }

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -5,6 +5,9 @@ namespace SupportPal\Pollcast\Model;
 use GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent\Uuid;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Date;
+
+use function json_encode;
 
 /**
  * @property-read string $id
@@ -50,24 +53,27 @@ class Message extends Model
         return $this->belongsTo(Member::class);
     }
 
-    public function setUuid(): self
-    {
-        $this->{$this->getKeyName()} = $this->generateUuid();
-
-        return $this;
-    }
-
-    public function touchTimestamps(): self
-    {
-        if ($this->usesTimestamps()) {
-            $this->updateTimestamps();
-        }
-
-        return $this;
-    }
-
     public function getDateFormat(): string
     {
         return 'Y-m-d H:i:s.u';
+    }
+
+    /**
+     * @param mixed[] $payload
+     * @return mixed[]
+     */
+    public static function make(string $channel, string $event, array $payload, ?string $member = null): array
+    {
+        $instance = new self;
+
+        return [
+            $instance->getKeyName() => $instance->generateUuid(),
+            'channel_id'            => $channel,
+            'member_id'             => $member,
+            'event'                 => $event,
+            'payload'               => json_encode($payload),
+            'created_at'            => Date::now(),
+            'updated_at'            => Date::now(),
+        ];
     }
 }

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -53,11 +53,6 @@ class Message extends Model
         return $this->belongsTo(Member::class);
     }
 
-    public function getDateFormat(): string
-    {
-        return 'Y-m-d H:i:s.u';
-    }
-
     /**
      * @param mixed[] $payload
      * @return mixed[]

--- a/src/PollcastBroadcaster.php
+++ b/src/PollcastBroadcaster.php
@@ -91,15 +91,10 @@ class PollcastBroadcaster extends Broadcaster
 
         $messages = new Collection;
         foreach ($channels as $channel) {
+            /** @var Channel $channel */
             $channel = Channel::query()->firstOrCreate(['name' => $channel]);
 
-            $message = new Message([
-                'channel_id' => $channel->id,
-                'event'      => $event,
-                'payload'    => $payload,
-            ]);
-
-            $messages->push($message->setUuid()->touchTimestamps()->getAttributes());
+            $messages->push(Message::make($channel->id, $event, $payload));
         }
 
         Message::insert($messages->toArray());


### PR DESCRIPTION
This PR works around https://bugs.php.net/bug.php?id=76386:
1. Use the Laravel query builder to insert new messages into the database, with fractional second precision. 
2. Use Laravel Eloquent to obtain messages from the database. Precision is not defined on the Eloquent model so, fractional seconds are lost. This is OK however so long as `orderBy('created_at')` is used in the SQL query to ensure data is ordered by the sql server before it's sent to the client. I don't think we have a current use case for viewing microsecond precision. We just want the correct order of messages.

It's not possible to use Eloquent for both insertion and selection. The `getDateFormat()` means timestamps are cast to the specified format. On PHP 7.2, fractional seconds or microseconds are not returned from the database and so Carbon complains that data is missing when casting the data.

TLDR; use the query builder if you need to insert fractional seconds. Have Eloquent pretend fractional second precision is not defined.
