### PR TITLE
fix: #8 - PHP 7.2 compatibility issue

### DIFF
--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 
 use function sprintf;
+use function phpversion;
+use function version_compare;
 
 /**
  * @property-read string $id
@@ -79,6 +81,9 @@ class Message extends Model
     /**
      * To get around PHP 7.2 PDO bug with fractional datetimes - https://bugs.php.net/bug.php?id=76386
      * https://github.com/laravel/framework/issues/3506#issuecomment-383877242
+     *
+     * @param  mixed  $value
+     * @return Carbon
      */
     protected function asDateTime($value): Carbon
     {
@@ -97,7 +102,7 @@ class Message extends Model
     {
         $query = parent::newQuery();
 
-        if ($this->usesTimestamps()) {
+        if (version_compare((string) phpversion(), '7.3', '<') && $this->usesTimestamps()) {
             $table = $this->getTable();
             $createdAt = $this->getCreatedAtColumn();
             $updatedAt = $this->getUpdatedAtColumn();

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -11,8 +11,8 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 
-use function sprintf;
 use function phpversion;
+use function sprintf;
 use function version_compare;
 
 /**

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -2,9 +2,16 @@
 
 namespace SupportPal\Pollcast\Model;
 
+use DateTimeImmutable;
 use GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent\Uuid;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+use function sprintf;
 
 /**
  * @property-read string $id
@@ -40,6 +47,9 @@ class Message extends Model
         'payload'    => 'json',
     ];
 
+    /** @var string */
+    protected $dateFormat = 'Y-m-d H:i:s.u';
+
     public function channel(): BelongsTo
     {
         return $this->belongsTo(Channel::class);
@@ -66,8 +76,37 @@ class Message extends Model
         return $this;
     }
 
-    public function getDateFormat(): string
+    /**
+     * To get around PHP 7.2 PDO bug with fractional datetimes - https://bugs.php.net/bug.php?id=76386
+     * https://github.com/laravel/framework/issues/3506#issuecomment-383877242
+     */
+    protected function asDateTime($value): Carbon
     {
-        return 'Y-m-d H:i:s.u';
+        try {
+            return parent::asDateTime($value);
+        } catch (InvalidArgumentException $e) {
+            return parent::asDateTime(new DateTimeImmutable($value));
+        }
+    }
+
+    /**
+     * To get around PHP 7.2 PDO bug with fractional datetimes - https://bugs.php.net/bug.php?id=76386
+     * https://github.com/laravel/framework/issues/3506#issuecomment-383877242
+     */
+    public function newQuery(): Builder
+    {
+        $query = parent::newQuery();
+
+        if ($this->usesTimestamps()) {
+            $table = $this->getTable();
+            $createdAt = $this->getCreatedAtColumn();
+            $updatedAt = $this->getUpdatedAtColumn();
+
+            $query->select()
+                ->addSelect(DB::raw(sprintf('CAST(%s.%s AS CHAR) as %s', $table, $createdAt, $createdAt)))
+                ->addSelect(DB::raw(sprintf('CAST(%s.%s AS CHAR) as %s', $table, $updatedAt, $updatedAt)));
+        }
+
+        return $query;
     }
 }


### PR DESCRIPTION
This PR works around https://bugs.php.net/bug.php?id=76386:

1. Handles `asDateTime` exception.
2. Updates query builder so `created_at` and `updated_at` are cast to char, which makes sure they are returned with the microseconds.