### PR TITLE
fix: #8 - use microseconds in messages call

### DIFF
--- a/src/Http/Controller/SubscriptionController.php
+++ b/src/Http/Controller/SubscriptionController.php
@@ -42,7 +42,7 @@ class SubscriptionController
         $messages = new Collection;
         $channels = $this->getAuthorisedChannels();
         if ($channels->count() > 0) {
-            $messages = $this->getMessagesForRequest($members, $request, $channels, $time);
+            $messages = $this->getMessagesForRequest($time, $members, $request, $channels);
         }
 
         return new JsonResponse([
@@ -61,10 +61,10 @@ class SubscriptionController
     }
 
     protected function getMessagesForRequest(
+        Carbon $time,
         Collection $members,
         Request $request,
-        Collection $channels,
-        Carbon $time
+        Collection $channels
     ): Collection {
         return Message::query()
             ->with('channel')

--- a/src/Http/Controller/SubscriptionController.php
+++ b/src/Http/Controller/SubscriptionController.php
@@ -65,8 +65,7 @@ class SubscriptionController
         Request $request,
         Collection $channels,
         Carbon $time
-    ): Collection
-    {
+    ): Collection {
         return Message::query()
             ->with('channel')
             ->where('created_at', '>=', $request->get('time'))

--- a/src/Http/Controller/SubscriptionController.php
+++ b/src/Http/Controller/SubscriptionController.php
@@ -42,7 +42,7 @@ class SubscriptionController
         $messages = new Collection;
         $channels = $this->getAuthorisedChannels();
         if ($channels->count() > 0) {
-            $messages = $this->getMessagesForRequest($members, $request, $channels);
+            $messages = $this->getMessagesForRequest($members, $request, $channels, $time);
         }
 
         return new JsonResponse([
@@ -60,11 +60,17 @@ class SubscriptionController
             ->pluck('pollcast_channel.name', 'pollcast_channel.id');
     }
 
-    protected function getMessagesForRequest(Collection $members, Request $request, Collection $channels): Collection
+    protected function getMessagesForRequest(
+        Collection $members,
+        Request $request,
+        Collection $channels,
+        Carbon $time
+    ): Collection
     {
         return Message::query()
             ->with('channel')
             ->where('created_at', '>=', $request->get('time'))
+            ->where('created_at', '<', $time->toDateTimeString('microsecond'))
             ->where(function ($query) use ($members, $channels, $request) {
                 $query->orWhereIn('member_id', $members->pluck('id'));
 

--- a/src/Http/Controller/SubscriptionController.php
+++ b/src/Http/Controller/SubscriptionController.php
@@ -47,7 +47,7 @@ class SubscriptionController
 
         return new JsonResponse([
             'status' => 'success',
-            'time'   => $time->toDateTimeString(),
+            'time'   => $time->toDateTimeString('microsecond'),
             'events' => $messages
         ]);
     }

--- a/tests/Functional/Controller/SubscriptionTest.php
+++ b/tests/Functional/Controller/SubscriptionTest.php
@@ -10,8 +10,10 @@ use SupportPal\Pollcast\Model\Message;
 use SupportPal\Pollcast\Tests\TestCase;
 
 use function factory;
+use function implode;
 use function route;
 use function session;
+use function vsprintf;
 
 class SubscriptionTest extends TestCase
 {
@@ -29,12 +31,12 @@ class SubscriptionTest extends TestCase
 
         $this->postAjax(route('supportpal.pollcast.receive'), [
             'channels' => [$channel->name],
-            'time'     => Carbon::now()->toDateTimeString(),
+            'time'     => Carbon::now()->toDateTimeString('microsecond'),
         ])
             ->assertStatus(200)
             ->assertJson([
                 'status' => 'success',
-                'time'   => Carbon::now()->toDateTimeString(),
+                'time'   => Carbon::now()->toDateTimeString('microsecond'),
                 'events' => [],
             ]);
     }
@@ -53,7 +55,7 @@ class SubscriptionTest extends TestCase
             ->assertStatus(200)
             ->assertJson([
                 'status' => 'success',
-                'time'   => Carbon::now()->toDateTimeString(),
+                'time'   => Carbon::now()->toDateTimeString('microsecond'),
                 'events' => [$message->load('channel')->toArray()],
             ]);
     }
@@ -77,7 +79,7 @@ class SubscriptionTest extends TestCase
             ->assertStatus(200)
             ->assertJson([
                 'status' => 'success',
-                'time'   => Carbon::now()->toDateTimeString(),
+                'time'   => Carbon::now()->toDateTimeString('microsecond'),
                 'events' => [$message1->load('channel')->toArray(), $message2->load('channel')->toArray()],
             ]);
     }
@@ -91,16 +93,33 @@ class SubscriptionTest extends TestCase
         $message2 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:56.023456']);
         $message3 = factory(Message::class)->create(['channel_id' => $channel->id, 'event' => $event, 'created_at' => '2021-06-01 11:59:56.123465']);
 
-        $this->postAjax(route('supportpal.pollcast.receive'), [
+        $params = [
             'channels' => [$channel->name => [$event]],
             'time'     => '2021-06-01 11:59:55',
-        ])
+        ];
+        $response = $this->postAjax(route('supportpal.pollcast.receive'), $params)
             ->assertStatus(200)
             ->assertJson([
                 'status' => 'success',
-                'time'   => Carbon::now()->toDateTimeString(),
-                'events' => [$message2->load('channel')->toArray(), $message1->load('channel')->toArray(), $message3->load('channel')->toArray()],
+                'time'   => Carbon::now()->toDateTimeString('microsecond'),
             ]);
+
+        $json = $response->decodeResponseJson();
+        $this->assertArrayHasKey('events', $json);
+
+        $expected = [$message2['id'], $message1['id'], $message3['id']];
+        foreach ($expected as $order => $id) {
+            $this->assertSame(
+                $id,
+                $json['events'][$order]['id'],
+                vsprintf('Key %d value %s does not match expected value %s. The expected order is: %s', [
+                    $order,
+                    $json['events'][$order]['id'],
+                    $id,
+                    implode(', ', $expected)
+                ])
+            );
+        }
     }
 
     public function testMessagesMemberUpdatedAtTouched(): void
@@ -109,12 +128,12 @@ class SubscriptionTest extends TestCase
 
         $this->postAjax(route('supportpal.pollcast.receive'), [
             'channels' => [$channel->name],
-            'time'     => Carbon::now()->toDateTimeString(),
+            'time'     => Carbon::now()->toDateTimeString('microsecond'),
         ])
             ->assertStatus(200)
             ->assertJson([
                 'status' => 'success',
-                'time'   => Carbon::now()->toDateTimeString(),
+                'time'   => Carbon::now()->toDateTimeString('microsecond'),
                 'events' => [],
             ]);
 
@@ -131,12 +150,12 @@ class SubscriptionTest extends TestCase
 
         $this->postAjax(route('supportpal.pollcast.receive'), [
             'channels' => [$channel1->name, $channel2->name],
-            'time'     => Carbon::now()->toDateTimeString(),
+            'time'     => Carbon::now()->toDateTimeString('microsecond'),
         ])
             ->assertStatus(200)
             ->assertJson([
                 'status' => 'success',
-                'time'   => Carbon::now()->toDateTimeString(),
+                'time'   => Carbon::now()->toDateTimeString('microsecond'),
                 'events' => [],
             ]);
 
@@ -154,7 +173,7 @@ class SubscriptionTest extends TestCase
     {
         $this->postAjax(route('supportpal.pollcast.receive'), [
             'channels' => ['fake-channel'],
-            'time'     => Carbon::now()->toDateTimeString(),
+            'time'     => Carbon::now()->toDateTimeString('microsecond'),
         ])
             ->assertStatus(404);
     }


### PR DESCRIPTION
Relates to #8

Since we moved to using microseconds, we are now able to use that when we are fetching messages. Also want to ensure it doesn't fetch any messages added after this time is generated to avoid potential duplicate results. 