### PR TITLE
fix: make user_info consistent with other Laravel broadcasters

### DIFF
--- a/src/PollcastBroadcaster.php
+++ b/src/PollcastBroadcaster.php
@@ -67,7 +67,7 @@ class PollcastBroadcaster extends Broadcaster
 
         return [
             'user_id'   => $user->getAuthIdentifier(),
-            'user_info' => $user,
+            'user_info' => $result,
         ];
     }
 

--- a/tests/Unit/PollcastBroadcasterTest.php
+++ b/tests/Unit/PollcastBroadcasterTest.php
@@ -34,7 +34,43 @@ class PollcastBroadcasterTest extends TestCase
 
         $this->assertEquals([
             'user_id' => $user->id,
+            'user_info' => true
+        ], $broadcaster->auth($request));
+    }
+
+    public function testAuthUserInfo(): void
+    {
+        $broadcaster = $this->setupBroadcaster();
+
+        $channelName = 'fake-channel';
+        $broadcaster->channel($channelName, function (User $user) {
+            return $user;
+        });
+
+        [$user, $request] = $this->setupRequest($channelName);
+
+        $this->assertEquals([
+            'user_id' => $user->id,
             'user_info' => $user
+        ], $broadcaster->auth($request));
+    }
+
+    public function testAuthUserInfoCustom(): void
+    {
+        $data = ['data' => '1234'];
+
+        $broadcaster = $this->setupBroadcaster();
+
+        $channelName = 'fake-channel';
+        $broadcaster->channel($channelName, function () use ($data) {
+            return $data;
+        });
+
+        [$user, $request] = $this->setupRequest($channelName);
+
+        $this->assertEquals([
+            'user_id' => $user->id,
+            'user_info' => $data
         ], $broadcaster->auth($request));
     }
 


### PR DESCRIPTION
Based on https://github.com/laravel/framework/blob/10.x/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php#L116 and https://github.com/pusher/pusher-http-php/blob/4ace4873873b06c25cecb2dd6d9fdcbf2f20b640/src/Pusher.php#L934, it should return `$result` for the `user_info`.