### PR TITLE
fix: remove filtering out messages by same socket

### DIFF
--- a/src/PollcastBroadcaster.php
+++ b/src/PollcastBroadcaster.php
@@ -5,7 +5,6 @@ namespace SupportPal\Pollcast;
 use Illuminate\Broadcasting\Broadcasters\Broadcaster;
 use Illuminate\Broadcasting\Broadcasters\UsePusherChannelConventions;
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use SupportPal\Pollcast\Broadcasting\Socket;
@@ -83,10 +82,6 @@ class PollcastBroadcaster extends Broadcaster
     {
         if ($this->hitsLottery()) {
             $this->gc();
-        }
-
-        if (Arr::get($payload, 'socket') === null) {
-            $payload['socket'] = $this->socket->id();
         }
 
         $messages = new Collection;

--- a/tests/Unit/PollcastBroadcasterTest.php
+++ b/tests/Unit/PollcastBroadcasterTest.php
@@ -117,37 +117,6 @@ class PollcastBroadcasterTest extends TestCase
         $this->assertDatabaseCount('pollcast_message_queue', 2);
     }
 
-    public function testBroadcastWithoutSocket(): void
-    {
-        $date = '2021-06-01 12:00:00';
-        Carbon::setTestNow(Carbon::parse($date));
-
-        $broadcaster = $this->setupBroadcaster();
-
-        $channelName1 = 'public-channel';
-        $channelName2 = 'private-channel';
-        $userFunction = function (User $user) {
-            return true;
-        };
-        $broadcaster->channel($channelName1, $userFunction);
-        $broadcaster->channel($channelName2, $userFunction);
-
-        $eventName = 'test-event';
-        $broadcaster->broadcast([$channelName1, $channelName2], $eventName, []);
-
-        $channels = Channel::get();
-        foreach ($channels as $channel) {
-            $this->assertDatabaseHas('pollcast_message_queue', [
-                'channel_id' => $channel->id,
-                'member_id'  => null,
-                'event'      => $eventName,
-                'payload'    => json_encode(['socket' => 'test']),
-            ]);
-        }
-
-        $this->assertDatabaseCount('pollcast_message_queue', 2);
-    }
-
     public function testBroadcastGarbageCollection(): void
     {
         // Update lottery so garbage collection always runs.


### PR DESCRIPTION
The other broadcasters don't filter out message by the same socket by default, there is a `orOthers` function available:
https://github.com/laravel/framework/blob/10.x/src/Illuminate/Broadcasting/PendingBroadcast.php#LL56C21-L56C29

We should try to implement this in our broadcaster.