### PR TITLE
fix: dont throw exceptions to users

### DIFF
--- a/src/Http/Controller/ChannelController.php
+++ b/src/Http/Controller/ChannelController.php
@@ -57,7 +57,7 @@ class ChannelController extends BroadcastController
 
     public function unsubscribe(UnsubscribeRequest $request): JsonResponse
     {
-        /** @var Channel $channel */
+        /** @var Channel|null $channel */
         $channel = Channel::query()
             ->where('name', $request->channel_name)
             ->first();
@@ -66,7 +66,7 @@ class ChannelController extends BroadcastController
             return new JsonResponse([false]);
         }
 
-        /** @var Member $member */
+        /** @var Member|null $member */
         $member = Member::query()
             ->where('channel_id', $channel->id)
             ->where('socket_id', $this->socket->id())

--- a/src/Http/Controller/ChannelController.php
+++ b/src/Http/Controller/ChannelController.php
@@ -60,13 +60,21 @@ class ChannelController extends BroadcastController
         /** @var Channel $channel */
         $channel = Channel::query()
             ->where('name', $request->channel_name)
-            ->firstOrFail();
+            ->first();
+
+        if ($channel === null) {
+            return new JsonResponse([false]);
+        }
 
         /** @var Member $member */
         $member = Member::query()
             ->where('channel_id', $channel->id)
             ->where('socket_id', $this->socket->id())
-            ->firstOrFail();
+            ->first();
+
+        if ($member === null) {
+            return new JsonResponse([false]);
+        }
 
         $this->socket->removeMemberFromChannel($member, $channel);
 

--- a/src/Http/Controller/PublishController.php
+++ b/src/Http/Controller/PublishController.php
@@ -16,7 +16,11 @@ class PublishController
     {
         $channel = Channel::query()
             ->where('name', $request->channel_name)
-            ->firstOrFail();
+            ->first();
+
+        if ($channel === null) {
+            return new JsonResponse([false]);
+        }
 
         (new Message([
             'channel_id' => $channel->id,

--- a/src/Http/Controller/PublishController.php
+++ b/src/Http/Controller/PublishController.php
@@ -14,6 +14,7 @@ class PublishController
      */
     public function publish(PublishRequest $request): JsonResponse
     {
+        /** @var Channel|null $channel */
         $channel = Channel::query()
             ->where('name', $request->channel_name)
             ->first();

--- a/src/Http/Controller/SubscriptionController.php
+++ b/src/Http/Controller/SubscriptionController.php
@@ -33,7 +33,7 @@ class SubscriptionController
         $memberQuery = Member::query()->where('socket_id', $this->socket->id());
         $members = $memberQuery->get();
         if ($members->isEmpty()) {
-            throw (new ModelNotFoundException)->setModel(Member::class);
+            return new JsonResponse(['status' => 'error']);
         }
 
         // Update the last active time of the member.

--- a/src/Http/Controller/SubscriptionController.php
+++ b/src/Http/Controller/SubscriptionController.php
@@ -2,7 +2,6 @@
 
 namespace SupportPal\Pollcast\Http\Controller;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;

--- a/src/Model/Channel.php
+++ b/src/Model/Channel.php
@@ -29,7 +29,7 @@ class Channel extends Model
     /** @var string[] */
     protected $guarded = [];
 
-    /** @var string[] */
+    /** @var array<int, string> */
     protected $fillable = ['name'];
 
     /** @var array<string, string> */

--- a/src/Model/Member.php
+++ b/src/Model/Member.php
@@ -32,7 +32,7 @@ class Member extends Model
     /** @var string[] */
     protected $guarded = [];
 
-    /** @var string[] */
+    /** @var array<int, string> */
     protected $fillable = ['channel_id', 'socket_id', 'data'];
 
     /** @var array<string, string> */

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -33,7 +33,7 @@ class Message extends Model
     /** @var string[] */
     protected $guarded = [];
 
-    /** @var string[] */
+    /** @var array<int, string> */
     protected $fillable = ['channel_id', 'member_id', 'event', 'payload'];
 
     /** @var array<string, string> */

--- a/tests/Functional/Controller/ChannelTest.php
+++ b/tests/Functional/Controller/ChannelTest.php
@@ -130,7 +130,8 @@ class ChannelTest extends TestCase
     public function testUnsubscribeChannelNotFound(): void
     {
         $this->postAjax(route('supportpal.pollcast.unsubscribe'), ['channel_name' => 'fake-channel'])
-            ->assertStatus(404);
+            ->assertStatus(200)
+            ->assertJson([false]);
     }
 
     public function testUnsubscribeMemberNotFound(): void
@@ -139,7 +140,8 @@ class ChannelTest extends TestCase
         $this->setupChannel($channelName);
 
         $this->postAjax(route('supportpal.pollcast.unsubscribe'), ['channel_name' => $channelName])
-            ->assertStatus(404);
+            ->assertStatus(200)
+            ->assertJson([false]);
     }
 
     public function testUnsubscribeMemberDifferentSocketId(): void
@@ -150,7 +152,8 @@ class ChannelTest extends TestCase
         Member::factory()->create(['channel_id' => $channel->id]);
 
         $this->postAjax(route('supportpal.pollcast.unsubscribe'), ['channel_name' => $channelName])
-            ->assertStatus(404);
+            ->assertStatus(200)
+            ->assertJson([false]);
     }
 
     /**

--- a/tests/Functional/Controller/PublishTest.php
+++ b/tests/Functional/Controller/PublishTest.php
@@ -40,7 +40,8 @@ class PublishTest extends TestCase
             'event'        => 'test-event',
             'data'         => ['user_id' => 1],
         ])
-            ->assertStatus(404);
+            ->assertStatus(200)
+            ->assertJson([false]);
     }
 
     public function testPublishValidation(): void

--- a/tests/Functional/Controller/SubscriptionTest.php
+++ b/tests/Functional/Controller/SubscriptionTest.php
@@ -204,7 +204,8 @@ class SubscriptionTest extends TestCase
             'channels' => ['fake-channel'],
             'time'     => Carbon::now()->toDateTimeString('microsecond'),
         ])
-            ->assertStatus(404);
+            ->assertStatus(200)
+            ->assertJson(['status' => 'error']);
     }
 
     public function testMessagesValidation(): void


### PR DESCRIPTION
When an exception is thrown it falls through to the user's exception handler. This creates an unknown from the library perspective as the response may not match what we expect or introduce unexpected behaviour. We should return an absolute response to prevent that.