### PR TITLE
Increase message lifetime to at least an hour (before garbage collection)

### DIFF
--- a/src/Http/Controller/SubscriptionController.php
+++ b/src/Http/Controller/SubscriptionController.php
@@ -99,17 +99,12 @@ class SubscriptionController
             ->lazy(100)
             // Remove events triggered by the same member (prevent unnecessary events).
             ->filter(function (Message $message) {
-                if ($this->messagesFound >= 10) {
-                    return false;
-                }
-
-                $sameSocket = Arr::get($message->payload, 'socket') === $this->socket->id();
-
-                if ($sameSocket) {
+                if ($this->messagesFound >= 10 || Arr::get($message->payload, 'socket') === $this->socket->id()) {
                     return false;
                 }
 
                 $this->messagesFound++;
+
                 return true;
             });
     }

--- a/src/PollcastBroadcaster.php
+++ b/src/PollcastBroadcaster.php
@@ -105,15 +105,13 @@ class PollcastBroadcaster extends Broadcaster
      */
     protected function gc(): void
     {
-        $pollingInterval = (int) config('pollcast.polling_interval', 5000);
-
         Message::query()
-            ->where('created_at', '<', Carbon::now()->subMilliseconds($pollingInterval * 6)->toDateTimeString())
+            ->where('created_at', '<', Carbon::now()->subHour()->toDateTimeString())
             ->delete();
 
         Member::query()
             ->with('channel')
-            ->where('updated_at', '<', Carbon::now()->subMilliseconds($pollingInterval * 6)->toDateTimeString())
+            ->where('updated_at', '<', Carbon::now()->subHour()->toDateTimeString())
             ->each(function (Member $member) {
                 /** @var Channel $channel */
                 $channel = $member->channel;


### PR DESCRIPTION
Currently messages are deleted by lottery on broadcasts made after being 30 seconds old, this will keep messages for at least an hour.