### PR TITLE
Fix deadlock on pollcast_channel_members

### DIFF
--- a/src/Http/Controller/SubscriptionController.php
+++ b/src/Http/Controller/SubscriptionController.php
@@ -36,7 +36,9 @@ class SubscriptionController
         }
 
         // Update the last active time of the member.
-        $memberQuery->update(['updated_at' => $time]);
+        Member::query()
+            ->whereIn('id', $members->pluck('id'))
+            ->update(['updated_at' => $time]);
 
         $messages = new Collection;
         $channels = $this->getAuthorisedChannels();


### PR DESCRIPTION
```
[2026-03-30T15:36:17.089108+00:00] production.ERROR: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction (Connection: mysql, SQL: update `pollcast_channel_members` set `pollcast_channel_members`.`updated_at` = 2026-03-30 15:36:17 where `socket_id` = pollcast-69ca98571b12f5.85880517) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 40001): SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction (Connection: mysql, SQL: update `pollcast_channel_members` set `pollcast_channel_members`.`updated_at` = 2026-03-30 15:36:17 where `socket_id` = pollcast-69ca98571b12f5.85880517) at /vendor/laravel/framework/src/Illuminate/Database/Connection.php:829)
[stacktrace]
#0 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(783): Illuminate\\Database\\Connection->runQueryCallback()
#1 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(619): Illuminate\\Database\\Connection->run()
#2 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(552): Illuminate\\Database\\Connection->affectingStatement()
#3 /vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(3603): Illuminate\\Database\\Connection->update()
#4 /vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1061): Illuminate\\Database\\Query\\Builder->update()
#5 /vendor/supportpal/pollcast/src/Http/Controller/SubscriptionController.php(42): Illuminate\\Database\\Eloquent\\Builder->update()
#6 /vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(46): SupportPal\\Pollcast\\Http\\Controller\\SubscriptionController->messages()
```

The deadlock was occurring because the code was updating `pollcast_channel_members` rows using `WHERE socket_id = '...',` which locks rows through a secondary index instead of the primary key. When multiple concurrent polling requests tried to update the same rows simultaneously, MySQL couldn't maintain a consistent lock order, causing deadlocks.